### PR TITLE
mysql버전을 8로 업그레이드

### DIFF
--- a/database/Dockerfile
+++ b/database/Dockerfile
@@ -1,3 +1,3 @@
-FROM mariadb:10
+FROM mariadb:10.3
 
 ENV TZ=Asia/Seoul

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -41,6 +41,7 @@ spring:
     properties:
       hibernate.format_sql: true
       hibernate.default_batch_fetch_size: 100
+    database-platform: org.hibernate.dialect.MySQL8Dialect
   sql.init.mode: always
   data:
     rest:


### PR DESCRIPTION
mysql버전을 8로 업그레이드하기위하여
mariadb의 버전을 업데이트하였고 dialect 지정