### PR TITLE
DB설정 변경

### DIFF
--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -56,7 +56,7 @@ spring:
     activate:
       on-profile: heroku
   datasource:
-    url: ${CLEARDB_WHITE_URL}
+    url: ${JAWSDB_URL}
   jpa:
     hibernate:
       ddl-auto: create


### PR DESCRIPTION
CLEARDB의 mysql default는 5.6이여서 mysql default 8.0인 jaws db로 변경

This closes #29 